### PR TITLE
Ignore sample video and add placeholder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Ignore large or generated binary assets
+public/sample/output.mp4
+*.mp4
+*.mov
+*.avi
+*.mkv
+*.webm
+*.zip
+*.tar
+*.gz
+*.bin

--- a/README.md
+++ b/README.md
@@ -145,3 +145,18 @@ npm run dev
 
 
 👉 이 문서는 최초 기획 README이며, 개발이 진행됨에 따라 업데이트될 예정입니다.
+
+## Sample Video
+
+The sample video `public/sample/output.mp4` is omitted from version control to keep the repository small.
+A placeholder is available in `public/sample`.
+
+To obtain the video:
+
+1. Generate your own clip with Manim, e.g.:
+   ```bash
+   manim path/to/scene.py SampleScene -o output.mp4
+   ```
+2. Or download the shared example and place it at `public/sample/output.mp4`.
+
+See `public/sample/README.md` for details.

--- a/public/sample/README.md
+++ b/public/sample/README.md
@@ -1,0 +1,13 @@
+# Sample Video Placeholder
+
+The example video `output.mp4` has been removed from version control to keep the repository light.
+
+To try the video player:
+
+1. Generate a sample clip with [Manim](https://docs.manim.community/):
+   ```bash
+   manim path/to/scene.py SampleScene -o output.mp4
+   ```
+2. Or place any MP4 file here and name it `output.mp4`.
+
+This directory and file act as placeholders so tooling expecting the sample video can still run.

--- a/public/sample/output.placeholder
+++ b/public/sample/output.placeholder
@@ -1,0 +1,2 @@
+This is a placeholder for the missing output.mp4 file.
+Generate or download a sample video and save it as output.mp4 in this directory to test the video player.


### PR DESCRIPTION
## Summary
- ignore `public/sample/output.mp4` and other large binary assets
- add placeholder and README under `public/sample` explaining how to add a sample video
- document how to obtain or render the sample video in the main README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7afca55f883228bb7619b332378e7