### PR TITLE
feat: scaffold ai-manim pipeline mvp

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/app/api/manim-code/route.ts
+++ b/app/api/manim-code/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import OpenAI from 'openai';
+import { z } from 'zod';
+
+const schema = z.object({ scenes: z.array(z.string()) });
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { scenes } = schema.parse(body);
+
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  await Promise.resolve(openai);
+
+  return NextResponse.json({ code: `# Manim code for ${scenes.join(', ')}` });
+}

--- a/app/api/ocr/route.ts
+++ b/app/api/ocr/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import OpenAI from 'openai';
+import { z } from 'zod';
+
+const schema = z.object({ image: z.string().optional() });
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({}));
+  schema.parse(body);
+
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  // Placeholder using openai
+  await Promise.resolve(openai); // avoid unused
+
+  return NextResponse.json({ text: 'Recognized text' });
+}

--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const schema = z.object({ code: z.string() });
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  schema.parse(body);
+
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+
+  return NextResponse.json({ videoUrl: 'https://www.w3schools.com/html/mov_bbb.mp4' });
+}

--- a/app/api/storyboard/route.ts
+++ b/app/api/storyboard/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import OpenAI from 'openai';
+import { z } from 'zod';
+
+const schema = z.object({ text: z.string() });
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { text } = schema.parse(body);
+
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  await Promise.resolve(openai);
+
+  return NextResponse.json({ scenes: [`Scene from ${text}`] });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,5 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body { @apply bg-gray-50; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="h-screen w-screen">{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+import React, { useEffect } from 'react';
+import ReactFlow, { Background } from 'reactflow';
+import 'reactflow/dist/style.css';
+import { useFlowStore } from '@/store/useFlowStore';
+import { initialNodes, initialEdges } from '@/data/initialFlow';
+import { PanelRight } from '@/components/panel-right';
+import { VideoViewer } from '@/components/video-viewer';
+import { Toolbar } from '@/components/toolbar';
+
+export default function Home() {
+  const { nodes, edges, setNodes, setEdges, select } = useFlowStore();
+
+  useEffect(() => {
+    setNodes(initialNodes);
+    setEdges(initialEdges);
+  }, [setNodes, setEdges]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <Toolbar />
+      <div className="flex flex-1">
+        <div className="flex-1">
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodeClick={(_, node) => select(node.id)}
+            fitView
+          >
+            <Background />
+          </ReactFlow>
+        </div>
+        <PanelRight />
+      </div>
+      <VideoViewer />
+    </div>
+  );
+}

--- a/components/panel-right.tsx
+++ b/components/panel-right.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { useFlowStore } from '@/store/useFlowStore';
+import { Textarea } from '@/components/ui/textarea';
+
+export function PanelRight() {
+  const { selected, nodes, updatePayload } = useFlowStore();
+  const node = nodes.find((n) => n.id === selected);
+  if (!node) return <aside className="w-64 border-l" />;
+
+  const payload: any = node.data.payload;
+  const value =
+    node.data.kind === 'ocr'
+      ? payload.text
+      : node.data.kind === 'storyboard'
+      ? payload.scenes.join('\n')
+      : node.data.kind === 'manim'
+      ? payload.code
+      : '';
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const v = e.target.value;
+    if (node.data.kind === 'ocr') updatePayload(node.id, { text: v });
+    if (node.data.kind === 'storyboard') updatePayload(node.id, { scenes: v.split('\n') });
+    if (node.data.kind === 'manim') updatePayload(node.id, { code: v });
+  };
+
+  return (
+    <aside className="w-64 border-l p-2">
+      <Textarea className="h-full" value={value} onChange={handleChange} />
+    </aside>
+  );
+}

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { Button } from '@/components/ui/button';
+import { useFlowStore } from '@/store/useFlowStore';
+
+export function Toolbar() {
+  const runAll = async () => {
+    const state = useFlowStore.getState();
+    const ocrRes = await fetch('/api/ocr', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({})
+    });
+    const ocr = await ocrRes.json();
+    state.updatePayload('ocr', { text: ocr.text });
+
+    const sbRes = await fetch('/api/storyboard', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: ocr.text })
+    });
+    const sb = await sbRes.json();
+    state.updatePayload('storyboard', { scenes: sb.scenes });
+
+    const mcRes = await fetch('/api/manim-code', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scenes: sb.scenes })
+    });
+    const mc = await mcRes.json();
+    state.updatePayload('manim', { code: mc.code });
+
+    const rRes = await fetch('/api/render', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: mc.code })
+    });
+    const r = await rRes.json();
+    state.updatePayload('render', { videoUrl: r.videoUrl });
+    state.setVideo(r.videoUrl);
+  };
+
+  return (
+    <div className="border-b p-2">
+      <Button onClick={runAll}>Run All</Button>
+    </div>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, ...props }, ref) => (
+    <button
+      className={cn('rounded-md bg-slate-900 px-4 py-2 text-white hover:bg-slate-700', className)}
+      ref={ref}
+      {...props}
+    />
+  )
+);
+Button.displayName = 'Button';

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={cn('w-full rounded-md border p-2', className)}
+      {...props}
+    />
+  )
+);
+Textarea.displayName = 'Textarea';

--- a/components/video-viewer.tsx
+++ b/components/video-viewer.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { useFlowStore } from '@/store/useFlowStore';
+
+export function VideoViewer() {
+  const { videoUrl } = useFlowStore();
+  if (!videoUrl) return null;
+  return (
+    <div className="border-t p-2">
+      <video src={videoUrl} controls className="w-full" />
+    </div>
+  );
+}

--- a/data/initialFlow.ts
+++ b/data/initialFlow.ts
@@ -1,0 +1,36 @@
+import { Node, Edge } from 'reactflow';
+import { FlowNodeData } from '@/types/nodes';
+
+export const initialNodes: Node<FlowNodeData>[] = [
+  {
+    id: 'ocr',
+    type: 'default',
+    position: { x: 0, y: 0 },
+    data: { id: 'ocr', kind: 'ocr', payload: { text: '' } }
+  },
+  {
+    id: 'storyboard',
+    type: 'default',
+    position: { x: 0, y: 150 },
+    data: { id: 'storyboard', kind: 'storyboard', payload: { scenes: [] } }
+  },
+  {
+    id: 'manim',
+    type: 'default',
+    position: { x: 0, y: 300 },
+    data: { id: 'manim', kind: 'manim', payload: { code: '' } }
+  },
+  {
+    id: 'render',
+    type: 'default',
+    position: { x: 300, y: 150 },
+    style: { width: 300, height: 200 },
+    data: { id: 'render', kind: 'render', payload: { videoUrl: '' } }
+  }
+];
+
+export const initialEdges: Edge[] = [
+  { id: 'e1', source: 'ocr', target: 'storyboard' },
+  { id: 'e2', source: 'storyboard', target: 'manim' },
+  { id: 'e3', source: 'manim', target: 'render' }
+];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | false)[]) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  experimental: {
+    reactCompiler: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "newmanim",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.0.0-canary",
+    "react": "19.0.0-rc",
+    "react-dom": "19.0.0-rc",
+    "zustand": "^4.5.2",
+    "zod": "^3.23.8",
+    "reactflow": "^11.10.1",
+    "lucide-react": "^0.352.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/node": "^20.11.30",
+    "@types/react": "^19.0.0",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "15.0.0-canary"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/store/useFlowStore.ts
+++ b/store/useFlowStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+import { Node, Edge } from 'reactflow';
+import { NodeKind, FlowNodeData } from '@/types/nodes';
+
+interface FlowState {
+  nodes: Node<FlowNodeData<NodeKind>>[];
+  edges: Edge[];
+  selected?: string;
+  videoUrl?: string;
+  setNodes: (nodes: Node<FlowNodeData<NodeKind>>[]) => void;
+  setEdges: (edges: Edge[]) => void;
+  select: (id?: string) => void;
+  updatePayload: (id: string, payload: any) => void;
+  setVideo: (url: string) => void;
+}
+
+export const useFlowStore = create<FlowState>((set) => ({
+  nodes: [],
+  edges: [],
+  selected: undefined,
+  videoUrl: undefined,
+  setNodes: (nodes) => set({ nodes }),
+  setEdges: (edges) => set({ edges }),
+  select: (id) => set({ selected: id }),
+  updatePayload: (id, payload) =>
+    set((state) => ({
+      nodes: state.nodes.map((n) =>
+        n.id === id ? { ...n, data: { ...n.data, payload } } : n
+      ),
+    })),
+  setVideo: (url) => set({ videoUrl: url }),
+}));
+
+const SNAP_KEY = 'flow-snapshots';
+if (typeof window !== 'undefined') {
+  useFlowStore.subscribe((state) => {
+    const snaps = JSON.parse(localStorage.getItem(SNAP_KEY) || '[]');
+    snaps.unshift({ nodes: state.nodes, edges: state.edges });
+    localStorage.setItem(SNAP_KEY, JSON.stringify(snaps.slice(0, 5)));
+  });
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/types/nodes.ts
+++ b/types/nodes.ts
@@ -1,0 +1,14 @@
+export type NodeKind = 'ocr' | 'storyboard' | 'manim' | 'render';
+
+export interface NodePayloads {
+  ocr: { text: string };
+  storyboard: { scenes: string[] };
+  manim: { code: string };
+  render: { videoUrl?: string };
+}
+
+export interface FlowNodeData<K extends NodeKind = NodeKind> {
+  id: string;
+  kind: K;
+  payload: NodePayloads[K];
+}


### PR DESCRIPTION
## Summary
- set up Next.js app router project with React Flow nodes for OCR, Storyboard, Manim, and Render
- add toolbar to sequentially call mock OpenAI-backed API routes and update node payloads
- provide right-side editor panel, bottom video viewer, and Zustand store with localStorage snapshots

## Testing
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json)*
- `npm run dev` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa24247c08322a0d753c60ce53fe2